### PR TITLE
history changes on button click

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,7 @@ function Square(props) {
 
       jumpTo(step) {
         this.setState({
+          history: this.state.history.slice(0, step+1),
           stepNumber: step,
           xIsNext: (step % 2) === 0,
         });


### PR DESCRIPTION
when clicking  "go to move #a" the Xs and Os change without the need for a click